### PR TITLE
Fix csproj paths and added NewsPatch

### DIFF
--- a/Scope.Client/Events/Patches/MainMenu/NewsPatch.cs
+++ b/Scope.Client/Events/Patches/MainMenu/NewsPatch.cs
@@ -1,0 +1,22 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="NewsPatch.cs" company="Scope SL">
+// Copyright (c) Scope SL. All rights reserved.
+// Licensed under the CC BY-SA 3.0 license.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Scope.Client.Events.Patches.QueryProcessor
+{
+#pragma warning disable SA1600 // Elements should be documented
+
+    using HarmonyLib;
+
+    /// <summary>
+    /// Patches <see cref="NewsLoader.Start"/>.
+    /// </summary>
+    [HarmonyPatch(typeof(NewsLoader), nameof(NewsLoader.Start))]
+    internal class NewsPatch
+    {
+        public static bool Prefix() => false;
+    }
+}

--- a/Scope.Client/Scope.Client.csproj
+++ b/Scope.Client/Scope.Client.csproj
@@ -65,7 +65,6 @@
     <Compile Include="API\Features\Packets\RoundStart.cs" />
     <Compile Include="API\Features\Packets\ConnectionSuccessful.cs" />
     <Compile Include="API\Interfaces\IMod.cs" />
-    <Compile Include="Events\Patches\TransmissionNetwork.cs" />
     <Compile Include="Loader\Config.cs" />
     <Compile Include="API\Features\Log.cs" />
     <Compile Include="API\Features\TransmissionNetworkObject.cs" />
@@ -73,6 +72,16 @@
     <Compile Include="Events\EventArgs\SendingDataEventArgs.cs" />
     <Compile Include="Events\EventArgs\ReceivingDataEventArgs.cs" />
     <Compile Include="Events\Events.cs" />
+    <Compile Include="Events\Patches\TransmissionNetwork\TargetPrintOnConsolePatch.cs" />
+    <Compile Include="Events\Patches\TransmissionNetwork\TransmissionStartPatch.cs" />
+    <Compile Include="Events\Patches\QueryProcessor\EcdsaSignPatch.cs" />
+    <Compile Include="Events\Patches\QueryProcessor\ConsoleAwakePatch.cs" />
+    <Compile Include="Events\Patches\QueryProcessor\CmdSendEncryptedQueryPatch.cs" />
+    <Compile Include="Events\Patches\QueryProcessor\UserCodeCmdSendEncryptedQueryPatch.cs" />
+    <Compile Include="Events\Patches\Authentication\ConnectedPatch.cs" />
+    <Compile Include="Events\Patches\Authentication\ConnectPatch.cs" />
+    <Compile Include="Events\Patches\Authentication\SignActionPatch.cs" />
+    <Compile Include="Events\Patches\MainMenu\NewsPatch.cs" />
     <Compile Include="Events\Handlers\Data.cs" />
     <Compile Include="Loader\BepInExLoader.cs" />
     <Compile Include="Loader\Loader.cs" />


### PR DESCRIPTION
NewsPatch allows us to override news and prevents the players from seeing the original news tab from the non-modded client version.